### PR TITLE
Add attendance tracking via Flag Pole

### DIFF
--- a/CommonBase/MissionScripts/attendanceTracker.sqf
+++ b/CommonBase/MissionScripts/attendanceTracker.sqf
@@ -1,0 +1,151 @@
+
+FormattedAttendanceList = [];
+publicVariable "FormattedAttendanceList";
+
+private _attendanceData = AttendanceTrackingData select 1;
+private _timeTrackingList = _attendanceData select 1;
+
+if (count _timeTrackingList > 0) then
+{
+	for [{_i = 0}, {_i < 300}, {_i = _i + 1}] do
+	{
+		if (_i <= ((count _timeTrackingList) - 1)) then
+		{
+			_totalMinutes = (_timeTrackingList select _i) select 1;
+			_hours = floor(_totalMinutes / 60);
+			_hoursString = "";
+			if (_hours < 10) then
+			{
+				_hoursString = "0" + str(_hours) + "h";
+			}
+			else
+			{
+				_hoursString = str(_hours) + "h";
+			};
+			
+			_minutes = _totalMinutes % 60;
+			_minutesString = "";
+			if (_minutes < 10) then
+			{
+				_minutesString = "0" + str(_minutes) + "m";
+			}
+			else
+			{
+				_minutesString = str(_minutes) + "m";
+			};
+			FormattedAttendanceList pushBack (((_timeTrackingList select _i) select 0) + " - " + _hoursString + _minutesString);
+		}
+		else
+		{
+			FormattedAttendanceList pushBack " - ";
+		}		
+	};
+};
+
+publicVariable "FormattedAttendanceList";
+
+while {true} do 
+{	
+	if (ActivateNewTracking) then
+	{
+		AttendanceTrackingData = [true,[[],[]]];
+		ActivateNewTracking = false;
+		AttendanceTrackingActive = true;
+		
+		profileNamespace setVariable ["SavedAttendanceTrackingData", AttendanceTrackingData];
+		saveProfileNamespace;
+	};
+	
+	if (DeactivateCurrentTracking) then
+	{		
+		DeactivateCurrentTracking = false;
+		AttendanceTrackingActive = false;		
+		AttendanceTrackingData set [0, false];
+		
+		profileNamespace setVariable ["SavedAttendanceTrackingData", AttendanceTrackingData];
+		saveProfileNamespace;
+	};
+
+	if (AttendanceTrackingActive) then
+	{
+		{		
+			private _attendanceData = AttendanceTrackingData select 1;
+			_idList = _attendanceData select 0;
+			
+			_playerId = getPlayerUID _x;
+			
+			if (_playerId in _idList) then 
+			{
+				_foundIndex = _idList find _playerId;
+				
+				_attendanceTimer = ((_attendanceData select 1) select _foundIndex) select 1;
+				_attendanceTimer = _attendanceTimer + 1;
+				
+				((_attendanceData select 1) select _foundIndex) set [1, _attendanceTimer];
+			}
+			else
+			{
+				(_attendanceData select 0) pushBack _playerId;
+				(_attendanceData select 1) pushBack [name _x, 0];
+			};
+			
+		} forEach allPlayers;
+		
+		AttendanceTrackingData set [0, true];		
+		
+		profileNamespace setVariable ["SavedAttendanceTrackingData", AttendanceTrackingData];
+		saveProfileNamespace;
+		
+		private _attendanceData = AttendanceTrackingData select 1;			
+		private _timeTrackingList = _attendanceData select 1;
+		FormattedAttendanceList = [];
+		
+		if (count _timeTrackingList > 0) then
+		{
+			for [{_i = 0}, {_i < 300}, {_i = _i + 1}] do
+			{
+				if (_i <= ((count _timeTrackingList) - 1)) then
+				{
+					_totalMinutes = (_timeTrackingList select _i) select 1;
+					_hours = floor(_totalMinutes / 60);
+					_hoursString = "";
+					if (_hours < 10) then
+					{
+						_hoursString = "0" + str(_hours) + "h";
+					}
+					else
+					{
+						_hoursString = str(_hours) + "h";
+					};
+					
+					_minutes = _totalMinutes % 60;
+					_minutesString = "";
+					if (_minutes < 10) then
+					{
+						_minutesString = "0" + str(_minutes) + "m";
+					}
+					else
+					{
+						_minutesString = str(_minutes) + "m";
+					};
+					FormattedAttendanceList pushBack (((_timeTrackingList select _i) select 0) + " - " + _hoursString + _minutesString);
+				}
+				else
+				{
+					FormattedAttendanceList pushBack " - ";
+				}		
+			};
+		};
+
+		publicVariable "FormattedAttendanceList";		
+	}	
+	else
+	{
+		AttendanceTrackingData set [0, false];
+		
+		profileNamespace setVariable ["SavedAttendanceTrackingData", AttendanceTrackingData];
+		saveProfileNamespace;
+	};	
+	
+	sleep 60;
+};

--- a/CommonBase/MissionScripts/showAttendance.sqf
+++ b/CommonBase/MissionScripts/showAttendance.sqf
@@ -1,0 +1,20 @@
+_page = _this select 3;
+
+_startIndex = 30 * (_page - 1);
+_endIndex = _startIndex + 30;
+
+_outputString = "";
+
+if (count FormattedAttendanceList > 0) then
+{
+	for [{_i = _startIndex},{_i < _endIndex},{_i = _i + 1}] do 
+	{
+		_outputString = _outputString + str(_i + 1) + ". " + (FormattedAttendanceList select _i) + "\n";
+	};
+
+	hint _outputString;
+}
+else
+{
+	hint "-";
+};

--- a/CommonBase/MissionScripts/startAttendanceTracking.sqf
+++ b/CommonBase/MissionScripts/startAttendanceTracking.sqf
@@ -1,0 +1,2 @@
+ActivateNewTracking = true;
+publicVariableServer "ActivateNewTracking";

--- a/CommonBase/MissionScripts/stopAttendanceTracking.sqf
+++ b/CommonBase/MissionScripts/stopAttendanceTracking.sqf
@@ -1,0 +1,2 @@
+DeactivateCurrentTracking = true;
+publicVariableServer "DeactivateCurrentTracking";

--- a/CommonBase/initPlayerLocal.sqf
+++ b/CommonBase/initPlayerLocal.sqf
@@ -89,3 +89,16 @@ player createDiaryRecord ["Diary",
 	<br/>VIV Helicopters can ACE Load one vehicle, VIV Planes can ACE Load two vehicles.
 	"]
 ];
+
+attendance_flag addAction["=START ATTENDANCE TRACKING=","MissionScripts\startAttendanceTracking.sqf","",1.5,true,true,"","(call BIS_fnc_admin) == 2",10];
+attendance_flag addAction["=STOP ATTENDANCE TRACKING=","MissionScripts\stopAttendanceTracking.sqf","",1.5,true,true,"","(call BIS_fnc_admin) == 2",10];
+attendance_flag addAction["=SHOW ATTENDANCE - PAGE 1=","MissionScripts\showAttendance.sqf",1,1.5,true,true,"","(call BIS_fnc_admin) == 2",10];
+attendance_flag addAction["=SHOW ATTENDANCE - PAGE 2=","MissionScripts\showAttendance.sqf",2,1.5,true,true,"","(call BIS_fnc_admin) == 2",10];
+attendance_flag addAction["=SHOW ATTENDANCE - PAGE 3=","MissionScripts\showAttendance.sqf",3,1.5,true,true,"","(call BIS_fnc_admin) == 2",10];
+attendance_flag addAction["=SHOW ATTENDANCE - PAGE 4=","MissionScripts\showAttendance.sqf",4,1.5,true,true,"","(call BIS_fnc_admin) == 2",10];
+attendance_flag addAction["=SHOW ATTENDANCE - PAGE 5=","MissionScripts\showAttendance.sqf",5,1.5,true,true,"","(call BIS_fnc_admin) == 2",10];
+attendance_flag addAction["=SHOW ATTENDANCE - PAGE 6=","MissionScripts\showAttendance.sqf",6,1.5,true,true,"","(call BIS_fnc_admin) == 2",10];
+attendance_flag addAction["=SHOW ATTENDANCE - PAGE 7=","MissionScripts\showAttendance.sqf",7,1.5,true,true,"","(call BIS_fnc_admin) == 2",10];
+attendance_flag addAction["=SHOW ATTENDANCE - PAGE 8=","MissionScripts\showAttendance.sqf",8,1.5,true,true,"","(call BIS_fnc_admin) == 2",10];
+attendance_flag addAction["=SHOW ATTENDANCE - PAGE 9=","MissionScripts\showAttendance.sqf",9,1.5,true,true,"","(call BIS_fnc_admin) == 2",10];
+attendance_flag addAction["=SHOW ATTENDANCE - PAGE 10=","MissionScripts\showAttendance.sqf",10,1.5,true,true,"","(call BIS_fnc_admin) == 2",10];

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Altis/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Altis/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Altis/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Altis/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=2030;
+		nextID=2031;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={15083.263,80.522011,17341.193};
-		dir[]={0.71612048,-0.48006362,-0.50668037};
-		up[]={0.39190078,0.87722903,-0.27728212};
-		aside[]={-0.5775879,3.2247044e-007,-0.81633967};
+		pos[]={15204.492,30.983715,17304.969};
+		dir[]={0.91395831,-0.4001604,-0.067661785};
+		up[]={0.39908671,0.9164378,-0.02954359};
+		aside[]={-0.073830113,2.9201328e-007,-0.99728739};
 	};
 };
 binarizationWanted=0;
@@ -74,7 +74,8 @@ addons[]=
 	"rhsusf_c_Caiman",
 	"FIR_A10C_F",
 	"rhsusf_c_melb",
-	"rhs_c_a2port_armor"
+	"rhs_c_a2port_armor",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -450,7 +451,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=969;
+		items=970;
 		class Item0
 		{
 			dataType="Marker";
@@ -39477,6 +39478,45 @@ class Mission
 			id=2029;
 			type="rhs_zsu234_aa";
 			atlOffset=2.3841858e-007;
+		};
+		class Item969
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={15223.407,21.962128,17308.084};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=2030;
+			type="Flag_US_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Bootcamp_ACR/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Bootcamp_ACR/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Bootcamp_ACR/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Bootcamp_ACR/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=665;
+		nextID=666;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={1519.6722,357.93906,1809.906};
-		dir[]={0.27143431,-0.49718308,-0.82409996};
-		up[]={0.15553834,0.86764419,-0.47222903};
-		aside[]={-0.94981009,1.2910459e-007,-0.3128404};
+		pos[]={1139.8119,283.5542,3725.8596};
+		dir[]={-0.20687723,-0.36242464,-0.90877235};
+		up[]={-0.080447614,0.93201166,-0.35339034};
+		aside[]={-0.9750641,-2.0419247e-007,0.22196926};
 	};
 };
 binarizationWanted=0;
@@ -63,7 +63,8 @@ addons[]=
 	"rhsusf_c_weapons",
 	"A3_Characters_F_Mark",
 	"rhsusf_c_Caiman",
-	"rhsusf_c_melb"
+	"rhsusf_c_melb",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -320,7 +321,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -371,7 +372,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=114;
+		items=115;
 		class Item0
 		{
 			dataType="Logic";
@@ -19800,6 +19801,45 @@ class Mission
 					};
 				};
 				nAttributes=2;
+			};
+		};
+		class Item114
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1133.8354,270.48914,3692.2896};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=665;
+			type="Flag_US_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
 			};
 		};
 	};

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Desert_E/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Desert_E/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Desert_E/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Desert_E/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=444;
+		nextID=445;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={289.53922,35.282768,1413.1068};
-		dir[]={-0.5341844,-0.27471682,-0.79950118};
-		up[]={-0.15262513,0.96152079,-0.2284303};
-		aside[]={-0.83149183,3.3307879e-007,0.55555809};
+		pos[]={33.457134,64.125999,-33.424763};
+		dir[]={0.014183426,-0.56922203,0.82206416};
+		up[]={0.0098195421,0.82218337,0.56913853};
+		aside[]={0.99985373,1.4092166e-008,-0.017250407};
 	};
 };
 binarizationWanted=0;
-sourceName="7Cav_RHS_InvadeAndAnnexv_1_2";
+sourceName="7Cav_RHS_InvadeAndAnnex_v1_2";
 addons[]=
 {
 	"A3_Modules_F_Curator_Curator",
@@ -59,7 +59,8 @@ addons[]=
 	"ace_compat_rhs_afrf3",
 	"rhsgref_c_weapons",
 	"rhsusf_c_weapons",
-	"A3_Characters_F_Mark"
+	"A3_Characters_F_Mark",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -290,7 +291,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -339,7 +340,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=117;
+		items=118;
 		class Item0
 		{
 			dataType="Logic";
@@ -19792,6 +19793,46 @@ class Mission
 			};
 			id=442;
 			type="ACE_medicalSupplyCrate";
+		};
+		class Item117
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={17.961178,31.477377,5.5088897};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=444;
+			type="Flag_US_F";
+			atlOffset=-0.028999329;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Malden/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Malden/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Malden/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Malden/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=986;
+		nextID=987;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={11333.266,47.265209,4216.3027};
-		dir[]={0.7485674,-0.5206846,0.41053742};
-		up[]={0.45653808,0.85374725,0.25037873};
-		aside[]={0.48086464,-6.0339516e-008,-0.87680227};
+		pos[]={8208.71,43.11047,10050.435};
+		dir[]={-0.75242668,-0.45660979,-0.47473857};
+		up[]={-0.38617256,0.88966542,-0.24365294};
+		aside[]={-0.53361154,-8.9523382e-008,0.84573889};
 	};
 };
 binarizationWanted=0;
@@ -72,7 +72,8 @@ addons[]=
 	"A3_Characters_F_Mark",
 	"FIR_A10C_F",
 	"rhsusf_c_melb",
-	"rhs_c_a2port_armor"
+	"rhs_c_a2port_armor",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -381,7 +382,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -432,7 +433,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=669;
+		items=670;
 		class Item0
 		{
 			dataType="Marker";
@@ -34169,6 +34170,45 @@ class Mission
 			};
 			id=985;
 			type="rhs_zsu234_aa";
+		};
+		class Item669
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={8187.9365,32.866806,10041.598};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=986;
+			type="Flag_US_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Mountains_ACR/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Mountains_ACR/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Mountains_ACR/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Mountains_ACR/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=494;
+		nextID=495;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={2154.8777,390.98102,507.58536};
-		dir[]={0.041714147,-0.34530011,-0.93757296};
-		up[]={0.015347922,0.93848979,-0.34496459};
-		aside[]={-0.99901801,1.8248102e-007,-0.044448961};
+		pos[]={1499.0256,379.81967,171.18219};
+		dir[]={-0.65752363,-0.72355288,0.21010041};
+		up[]={-0.68922377,0.69026738,0.22022966};
+		aside[]={0.30437306,-1.4144462e-007,0.95255738};
 	};
 };
 binarizationWanted=0;
@@ -64,7 +64,8 @@ addons[]=
 	"rhsgref_c_weapons",
 	"rhsusf_c_weapons",
 	"A3_Characters_F_Mark",
-	"rhsusf_c_melb"
+	"rhsusf_c_melb",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -330,7 +331,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -380,7 +381,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=150;
+		items=151;
 		class Item0
 		{
 			dataType="Marker";
@@ -23657,6 +23658,46 @@ class Mission
 					};
 				};
 				nAttributes=2;
+			};
+		};
+		class Item150
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1476.8795,361.27139,168.11931};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=494;
+			type="Flag_US_F";
+			atlOffset=-0.028991699;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
 			};
 		};
 	};

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.ProvingGrounds_PMC/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.ProvingGrounds_PMC/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.ProvingGrounds_PMC/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.ProvingGrounds_PMC/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=384;
+		nextID=385;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={115.2235,60.448704,1436.6096};
-		dir[]={0.35543564,-0.50545883,-0.78627068};
-		up[]={0.2082164,0.86284173,-0.46060315};
-		aside[]={-0.91124058,4.7649519e-007,-0.41192916};
+		pos[]={1931.1982,73.192352,265.40384};
+		dir[]={-0.5103035,-0.59890962,-0.61717778};
+		up[]={-0.38164029,0.80081636,-0.46156806};
+		aside[]={-0.77068299,1.8029823e-007,0.63722736};
 	};
 };
 binarizationWanted=0;
@@ -59,7 +59,8 @@ addons[]=
 	"ace_compat_rhs_afrf3",
 	"rhsgref_c_weapons",
 	"rhsusf_c_weapons",
-	"A3_Characters_F_Mark"
+	"A3_Characters_F_Mark",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -288,7 +289,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -339,7 +340,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=114;
+		items=115;
 		class Item0
 		{
 			dataType="Marker";
@@ -9885,7 +9886,7 @@ class Mission
 			position[]={1912.8086,52.91473,259.34009};
 			name="respawn_west";
 			type="Empty";
-			angle=222.04504;
+			angle=222.04503;
 			id=190;
 		};
 		class Item28
@@ -19498,6 +19499,45 @@ class Mission
 								};
 							};
 							value="[[[[""launch_NLAW_F"",""arifle_MX_F"",""arifle_MX_SW_F"",""FirstAidKit""],[1,2,1,10]],[[""30Rnd_65x39_caseless_mag"",""16Rnd_9x21_Mag"",""30Rnd_45ACP_Mag_SMG_01"",""20Rnd_762x51_Mag"",""100Rnd_65x39_caseless_mag"",""1Rnd_HE_Grenade_shell"",""3Rnd_HE_Grenade_shell"",""1Rnd_Smoke_Grenade_shell"",""1Rnd_SmokeGreen_Grenade_shell"",""Chemlight_green"",""NLAW_F"",""Laserbatteries"",""HandGrenade"",""MiniGrenade"",""SmokeShell"",""SmokeShellGreen"",""UGL_FlareWhite_F"",""UGL_FlareGreen_F"",""ACE_SpareBarrel"",""ACE_20Rnd_65x47_Scenar_mag"",""ACE_30Rnd_65x47_Scenar_mag"",""ACE_20Rnd_65_Creedmor_mag"",""ACE_30Rnd_65_Creedmor_mag"",""ACE_10Rnd_762x51_M118LR_Mag"",""ACE_20Rnd_762x51_M118LR_Mag"",""ACE_10Rnd_762x51_Mk316_Mod_0_Mag"",""ACE_20Rnd_762x51_Mk316_Mod_0_Mag"",""ACE_10Rnd_762x51_Mk319_Mod_0_Mag"",""ACE_20Rnd_762x51_Mk319_Mod_0_Mag"",""ACE_20Rnd_762x51_Mag_Tracer"",""ACE_20Rnd_762x51_Mag_Tracer_Dim""],[24,6,6,6,6,3,1,2,2,6,3,2,6,6,2,2,2,2,2,4,4,4,4,4,4,4,4,4,4,4,4]],[[""Laserdesignator"",""acc_flashlight"",""bipod_01_F_blk"",""ACE_Chemlight_Shield"",""ACE_EarPlugs""],[1,2,1,12,12]],[[""B_Kitbag_mcamo""],[2]]],false]";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item114
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1919.3268,56.673119,244.4649};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=384;
+			type="Flag_US_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
 						};
 					};
 				};

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Shapur_BAF/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Shapur_BAF/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Shapur_BAF/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Shapur_BAF/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=410;
+		nextID=411;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={803.73334,73.231171,272.93814};
-		dir[]={-0.29092973,-0.4757863,0.83006006};
-		up[]={-0.1573748,0.87955272,0.44901028};
-		aside[]={0.9437179,-1.1730299e-007,0.33076599};
+		pos[]={783.76105,81.150719,236.58835};
+		dir[]={-0.15814306,-0.44187313,0.88304275};
+		up[]={-0.077896841,0.89706558,0.4349623};
+		aside[]={0.98435533,-3.5532867e-007,0.17628479};
 	};
 };
 binarizationWanted=0;
@@ -59,7 +59,8 @@ addons[]=
 	"ace_compat_rhs_afrf3",
 	"rhsgref_c_weapons",
 	"rhsusf_c_weapons",
-	"A3_Characters_F_Mark"
+	"A3_Characters_F_Mark",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -290,7 +291,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -341,7 +342,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=125;
+		items=126;
 		class Item0
 		{
 			dataType="Marker";
@@ -19838,6 +19839,46 @@ class Mission
 			};
 			id=409;
 			type="ACE_medicalSupplyCrate";
+		};
+		class Item125
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={728.19788,39.327805,434.42371};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=410;
+			type="Flag_US_F";
+			atlOffset=-0.028999329;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Stratis/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Stratis/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Stratis/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Stratis/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=1010;
+		nextID=1011;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={1534.9169,15.980783,5034.6484};
-		dir[]={-0.43508175,-0.46725586,-0.76966864};
-		up[]={-0.22993948,0.8841204,-0.40676802};
-		aside[]={-0.87054569,2.3149914e-007,0.49210411};
+		pos[]={2115.4341,19.376442,5701.0605};
+		dir[]={0.37486181,-0.44993865,0.81059587};
+		up[]={0.18886168,0.89305639,0.40839306};
+		aside[]={0.90766257,1.2292003e-007,-0.41974685};
 	};
 };
 binarizationWanted=0;
@@ -63,7 +63,8 @@ addons[]=
 	"rhsusf_c_weapons",
 	"A3_Characters_F_Mark",
 	"rhs_sounds",
-	"rhsusf_c_melb"
+	"rhsusf_c_melb",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -373,7 +374,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=511;
+		items=512;
 		class Item0
 		{
 			dataType="Marker";
@@ -27639,6 +27640,46 @@ class Mission
 					};
 				};
 				nAttributes=2;
+			};
+		};
+		class Item511
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2125.0134,10.202307,5718.1997};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=1010;
+			type="Flag_US_F";
+			atlOffset=-0.028999329;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
 			};
 		};
 	};

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Tanoa/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Tanoa/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 12, 9, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Tanoa/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Tanoa/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=838;
+		nextID=839;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={7233.2695,31.169682,7386.3999};
-		dir[]={-0.65258312,-0.25747463,0.7126475};
-		up[]={-0.17388864,0.96628481,0.18989347};
-		aside[]={0.73751521,1.0174699e-007,0.67535359};
+		pos[]={2513.7144,99.072189,13139.153};
+		dir[]={-0.63324219,-0.44857538,0.6307165};
+		up[]={-0.31782749,0.89374071,0.31655985};
+		aside[]={0.70569825,1.960434e-007,0.70852423};
 	};
 };
 binarizationWanted=0;
@@ -80,7 +80,8 @@ addons[]=
 	"rhs_c_trucks",
 	"FIR_A10C_F",
 	"rhsusf_c_melb",
-	"rhs_c_a2port_armor"
+	"rhs_c_a2port_armor",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -456,7 +457,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=454;
+		items=455;
 		class Item0
 		{
 			dataType="Marker";
@@ -28448,6 +28449,46 @@ class Mission
 			};
 			id=837;
 			type="rhs_zsu234_aa";
+		};
+		class Item454
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={2321.3005,15.771528,13160.196};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=838;
+			type="Flag_US_F";
+			atlOffset=-0.028999329;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Woodland_ACR/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Woodland_ACR/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Woodland_ACR/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.Woodland_ACR/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=510;
+		nextID=511;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={1106.7944,99.085884,-119.37188};
-		dir[]={-0.10365675,-0.39029658,-0.91484034};
-		up[]={-0.043941859,0.92068678,-0.3878167};
-		aside[]={-0.99364531,1.3247154e-007,0.11258508};
+		pos[]={6803.6421,91.076378,7606.3701};
+		dir[]={-0.75409096,-0.52073324,0.40023461};
+		up[]={-0.45996305,0.85371721,0.24412608};
+		aside[]={0.46881181,1.1175871e-008,0.88329941};
 	};
 };
 binarizationWanted=0;
@@ -68,7 +68,8 @@ addons[]=
 	"RHS_US_A2_AirImport",
 	"rhsusf_c_HEMTT_A4",
 	"rhsusf_c_Caiman",
-	"rhsusf_c_melb"
+	"rhsusf_c_melb",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -360,7 +361,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -411,7 +412,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=156;
+		items=157;
 		class Item0
 		{
 			dataType="Logic";
@@ -23148,6 +23149,46 @@ class Mission
 					};
 				};
 				nAttributes=2;
+			};
+		};
+		class Item156
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={6777.4688,69.010857,7624.5942};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=510;
+			type="Flag_US_F";
+			atlOffset=-0.028999329;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
 			};
 		};
 	};

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.cain/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.cain/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.cain/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.cain/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=676;
+		nextID=677;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={1532.2463,153.47595,11594.671};
-		dir[]={0.12868997,-0.37679589,0.91731983};
-		up[]={0.052348275,0.9262929,0.37314579};
-		aside[]={0.99030739,2.7765054e-008,-0.13892935};
+		pos[]={6780.147,49.644405,3800.3523};
+		dir[]={-0.44861808,-0.44387954,0.7757048};
+		up[]={-0.2222247,0.89608425,0.38424867};
+		aside[]={0.86565781,1.8277206e-008,0.50064063};
 	};
 };
 binarizationWanted=0;
@@ -72,7 +72,8 @@ addons[]=
 	"A3_Characters_F_Mark",
 	"FIR_A10C_F",
 	"rhsusf_c_melb",
-	"rhs_c_a2port_armor"
+	"rhs_c_a2port_armor",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -381,7 +382,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -431,7 +432,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=341;
+		items=342;
 		class Item0
 		{
 			dataType="Marker";
@@ -28327,6 +28328,46 @@ class Mission
 			};
 			id=675;
 			type="rhs_zsu234_aa";
+		};
+		class Item341
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={6755.2251,23.146076,3841.3879};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=676;
+			type="Flag_US_F";
+			atlOffset=-0.028999329;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.chernarus_summer/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.chernarus_summer/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.chernarus_summer/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.chernarus_summer/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=1045;
+		nextID=1046;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={4513.9468,342.1394,10290.591};
-		dir[]={0.24358308,-0.44600195,-0.86127669};
-		up[]={0.12137789,0.8950181,-0.42918172};
-		aside[]={-0.96227831,-1.7043203e-007,-0.27214622};
+		pos[]={4739.5698,353.17044,10348.547};
+		dir[]={-0.71038884,-0.54893649,-0.44048256};
+		up[]={-0.46653056,0.83586103,-0.28927597};
+		aside[]={-0.52697688,1.8332503e-007,0.84988219};
 	};
 };
 binarizationWanted=0;
@@ -73,7 +73,8 @@ addons[]=
 	"A3_Characters_F_Mark",
 	"FIR_A10C_F",
 	"rhsusf_c_melb",
-	"rhs_c_a2port_armor"
+	"rhs_c_a2port_armor",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -389,7 +390,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -440,7 +441,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=692;
+		items=693;
 		class Item0
 		{
 			dataType="Logic";
@@ -34230,6 +34231,46 @@ class Mission
 			};
 			id=1044;
 			type="rhs_zsu234_aa";
+		};
+		class Item692
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={4723.0493,342.94781,10340.795};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=1045;
+			type="Flag_US_F";
+			atlOffset=-0.028991699;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.desert_island/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.desert_island/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.desert_island/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.desert_island/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=540;
+		nextID=541;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=49;
+		nextID=52;
 	};
 	class Camera
 	{
-		pos[]={10900.324,38.010254,4035.0337};
-		dir[]={-0.34217131,-0.35018185,-0.87195891};
-		up[]={-0.12792417,0.93667787,-0.32599247};
-		aside[]={-0.93090218,2.5628833e-007,0.36530119};
+		pos[]={1392.0547,31.888969,955.46606};
+		dir[]={-0.31896684,-0.59445834,0.73816442};
+		up[]={-0.23579758,0.80412459,0.54569304};
+		aside[]={0.91796684,4.764297e-008,0.39666066};
 	};
 };
 binarizationWanted=0;
@@ -74,7 +74,8 @@ addons[]=
 	"rhsgref_c_weapons",
 	"rhsusf_c_weapons",
 	"A3_Characters_F_Mark",
-	"A3_Boat_F_Exp_Boat_Transport_02"
+	"A3_Boat_F_Exp_Boat_Transport_02",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -335,7 +336,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -385,7 +386,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=62;
+		items=63;
 		class Item0
 		{
 			dataType="Layer";
@@ -16712,6 +16713,45 @@ class Mission
 								};
 							};
 							value="[[[[],[]],[[],[]],[[],[]],[[],[]]],false]";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item62
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1382.1858,20.099609,971.49829};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=540;
+			type="Flag_US_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
 						};
 					};
 				};

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.eden/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.eden/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.eden/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.eden/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=1130;
+		nextID=1131;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={1186.9203,97.645447,11522.396};
-		dir[]={-0.31551957,-0.29840225,-0.90078384};
-		up[]={-0.09864632,0.95443803,-0.28162801};
-		aside[]={-0.94378084,7.286144e-008,0.33058};
+		pos[]={4848.4497,41.010311,11702.794};
+		dir[]={0.75995588,-0.63043779,-0.15821463};
+		up[]={0.61720675,0.77624017,-0.12849645};
+		aside[]={-0.2038202,2.8064824e-007,-0.9790169};
 	};
 };
 binarizationWanted=0;
@@ -73,7 +73,8 @@ addons[]=
 	"A3_Characters_F_Mark",
 	"FIR_A10C_F",
 	"rhsusf_c_melb",
-	"rhs_c_a2port_armor"
+	"rhs_c_a2port_armor",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -389,7 +390,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -437,7 +438,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=436;
+		items=437;
 		class Item0
 		{
 			dataType="Object";
@@ -29815,6 +29816,46 @@ class Mission
 			};
 			id=1129;
 			type="rhs_zsu234_aa";
+		};
+		class Item436
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={4858.7222,28.704391,11695.724};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=1130;
+			type="Flag_US_F";
+			atlOffset=-0.028999329;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.intro/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.intro/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.intro/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.intro/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=249;
+		nextID=250;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={2515.719,22.391191,2988.9963};
-		dir[]={-0.18733551,-0.46586326,-0.86480463};
-		up[]={-0.098628737,0.88485706,-0.4553054};
-		aside[]={-0.97733742,-1.4510806e-007,0.2117127};
+		pos[]={339.4133,35.835968,5006.7661};
+		dir[]={0.93783075,-0.34712109,-0.0028432822};
+		up[]={0.34713322,0.93781388,-0.0010527634};
+		aside[]={-0.0030323954,-2.5796271e-007,-1.0000117};
 	};
 };
 binarizationWanted=0;
@@ -57,7 +57,8 @@ addons[]=
 	"rhsusf_c_weapons",
 	"A3_Characters_F_Mark",
 	"A3_Boat_F_Exp_Boat_Transport_02",
-	"A3_Boat_F_Jets_Carrier_01"
+	"A3_Boat_F_Jets_Carrier_01",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -281,7 +282,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -331,7 +332,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=59;
+		items=60;
 		class Item0
 		{
 			dataType="Marker";
@@ -14074,6 +14075,45 @@ class Mission
 			id=248;
 			type="Land_Carrier_01_base_F";
 			atlOffset=74.669731;
+		};
+		class Item59
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={364.1843,27.505249,5007.0117};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=249;
+			type="Flag_US_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.noe/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.noe/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.noe/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.noe/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=854;
+		nextID=855;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={1518.1287,15.031746,6081.8896};
-		dir[]={0.79391032,-0.45744574,0.40057114};
-		up[]={0.40840715,0.88923705,0.20606394};
-		aside[]={0.45046523,7.1595423e-009,-0.89279824};
+		pos[]={1673.381,38.941326,5342.4668};
+		dir[]={0.00057488208,-0.49296141,0.87005299};
+		up[]={0.00032567367,0.87004846,0.49296269};
+		aside[]={1.0000014,7.004644e-009,-0.0006608073};
 	};
 };
 binarizationWanted=0;
@@ -72,7 +72,8 @@ addons[]=
 	"A3_Characters_F_Mark",
 	"FIR_A10C_F",
 	"rhsusf_c_melb",
-	"rhs_c_a2port_armor"
+	"rhs_c_a2port_armor",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -381,7 +382,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -430,7 +431,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=497;
+		items=498;
 		class Item0
 		{
 			dataType="Marker";
@@ -30555,6 +30556,46 @@ class Mission
 			id=853;
 			type="rhs_zsu234_aa";
 			atlOffset=-9.5367432e-007;
+		};
+		class Item497
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1677.3804,26.06044,5358.9795};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=854;
+			type="Flag_US_F";
+			atlOffset=-0.028999329;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.porto/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.porto/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.porto/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.porto/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=514;
 	class ItemIDProvider
 	{
-		nextID=523;
+		nextID=524;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={1978.6709,21.494165,2373.5767};
-		dir[]={-0.079120606,-0.49616024,-0.86462444};
-		up[]={-0.045214105,0.86823082,-0.49409696};
-		aside[]={-0.99584395,-6.632763e-008,0.091127656};
+		pos[]={312.56921,39.384609,5060.6362};
+		dir[]={0.65790218,-0.41150782,-0.63074911};
+		up[]={0.29704845,0.91140336,-0.2847881};
+		aside[]={-0.69206005,2.6571797e-008,-0.72185218};
 	};
 };
 binarizationWanted=0;
@@ -57,7 +57,8 @@ addons[]=
 	"rhsusf_c_troops",
 	"ace_explosives",
 	"A3_Boat_F_Exp_Boat_Transport_02",
-	"A3_Boat_F_Jets_Carrier_01"
+	"A3_Boat_F_Jets_Carrier_01",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -281,7 +282,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -331,7 +332,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=59;
+		items=60;
 		class Item0
 		{
 			dataType="Marker";
@@ -14084,6 +14085,45 @@ class Mission
 			id=522;
 			type="Land_Carrier_01_base_F";
 			atlOffset=34.291962;
+		};
+		class Item59
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={329.22418,27.56625,5049.5137};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=523;
+			type="Flag_US_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.sara/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.sara/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.sara/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.sara/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=836;
+		nextID=837;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={2621.4219,64.664116,2583.5825};
-		dir[]={-0.50219458,-0.40870142,0.76209182};
-		up[]={-0.22488727,0.91266513,0.34127194};
-		aside[]={0.83501512,-1.9707659e-007,0.55024838};
+		pos[]={9473.5557,155.37056,9850.5967};
+		dir[]={-0.88502854,-0.46525085,-0.016609281};
+		up[]={-0.4651714,0.88517779,-0.0087298471};
+		aside[]={-0.018763777,-5.1794814e-008,0.99982798};
 	};
 };
 binarizationWanted=0;
@@ -73,7 +73,8 @@ addons[]=
 	"A3_Characters_F_Mark",
 	"FIR_A10C_F",
 	"rhsusf_c_melb",
-	"rhs_c_a2port_armor"
+	"rhs_c_a2port_armor",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -439,7 +440,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=524;
+		items=525;
 		class Item0
 		{
 			dataType="Marker";
@@ -31874,6 +31875,46 @@ class Mission
 			id=835;
 			type="rhs_zsu234_aa";
 			atlOffset=9.5367432e-007;
+		};
+		class Item524
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={9454.6035,143.94281,9846.5303};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=836;
+			type="Flag_US_F";
+			atlOffset=-0.028991699;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.saralite/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.saralite/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.saralite/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.saralite/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=832;
+		nextID=833;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={3788.1919,45.985363,3097.0061};
-		dir[]={-0.25268847,-0.46024534,-0.85108435};
-		up[]={-0.13099688,0.887788,-0.44121495};
-		aside[]={-0.9586488,-5.8735168e-008,0.28462398};
+		pos[]={4591.7407,151.33002,7089.8379};
+		dir[]={-0.89686966,-0.44134906,-0.028951423};
+		up[]={-0.44112098,0.89733553,-0.014239538};
+		aside[]={-0.032264035,5.1504685e-008,0.9994812};
 	};
 };
 binarizationWanted=0;
@@ -73,7 +73,8 @@ addons[]=
 	"A3_Characters_F_Mark",
 	"FIR_A10C_F",
 	"rhsusf_c_melb",
-	"rhs_c_a2port_armor"
+	"rhs_c_a2port_armor",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -389,7 +390,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -439,7 +440,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=496;
+		items=497;
 		class Item0
 		{
 			dataType="Marker";
@@ -31244,6 +31245,46 @@ class Mission
 			};
 			id=831;
 			type="rhs_zsu234_aa";
+		};
+		class Item496
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={4575.2886,143.93222,7085.4961};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=832;
+			type="Flag_US_F";
+			atlOffset=-0.029006958;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.takistan/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.takistan/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.takistan/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.takistan/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=929;
+		nextID=930;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={5911.3047,148.73053,11286.97};
-		dir[]={0.59143096,-0.30351838,0.74706304};
-		up[]={0.18839951,0.95282507,0.23797493};
-		aside[]={0.78404891,1.2204691e-007,-0.62071204};
+		pos[]={6126.8965,96.67601,11449.31};
+		dir[]={0.88073808,-0.40616336,0.24362949};
+		up[]={0.39146653,0.91379893,0.1082866};
+		aside[]={0.26660937,2.6388443e-007,-0.96381533};
 	};
 };
 binarizationWanted=0;
@@ -72,7 +72,8 @@ addons[]=
 	"RHS_US_A2Port_Armor",
 	"FIR_A10C_F",
 	"rhsusf_c_melb",
-	"rhs_c_a2port_armor"
+	"rhs_c_a2port_armor",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -383,7 +384,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -433,7 +434,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=603;
+		items=604;
 		class Item0
 		{
 			dataType="Marker";
@@ -33305,6 +33306,46 @@ class Mission
 			};
 			id=928;
 			type="rhs_zsu234_aa";
+		};
+		class Item603
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={6148.7139,83.934288,11455.482};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=929;
+			type="Flag_US_F";
+			atlOffset=-0.028999329;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.utes/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.utes/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.utes/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.utes/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=240;
+		nextID=241;
 	};
 	class MarkerIDProvider
 	{
@@ -16,14 +16,14 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={1413.4479,89.580376,729.2793};
-		dir[]={0.14798677,-0.47616377,0.86681962};
-		up[]={0.080133282,0.87935519,0.46937388};
-		aside[]={0.98574072,-9.0694812e-009,-0.16828933};
+		pos[]={1310.4117,64.84761,749.80084};
+		dir[]={-0.037018452,-0.39760116,0.91682637};
+		up[]={-0.01604213,0.91755652,0.39728671};
+		aside[]={0.99920022,-4.8986294e-008,0.040345922};
 	};
 };
 binarizationWanted=0;
-sourceName="7Cav_RHS_InvadeAndAnnex_v1_1";
+sourceName="7Cav_RHS_InvadeAndAnnex_v1_2";
 addons[]=
 {
 	"A3_Ui_F",
@@ -56,7 +56,8 @@ addons[]=
 	"rhsgref_c_weapons",
 	"rhsusf_c_weapons",
 	"A3_Characters_F_Mark",
-	"A3_Boat_F_Exp_Boat_Transport_02"
+	"A3_Boat_F_Exp_Boat_Transport_02",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -324,7 +325,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=59;
+		items=60;
 		class Item0
 		{
 			dataType="Marker";
@@ -13950,6 +13951,45 @@ class Mission
 								};
 							};
 							value="[[[[],[]],[[],[]],[[],[]],[[],[]]],false]";
+						};
+					};
+				};
+				nAttributes=1;
+			};
+		};
+		class Item59
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={1383.8679,19.861904,971.3808};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=240;
+			type="Flag_US_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
 						};
 					};
 				};

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.zargabad/initServer.sqf
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.zargabad/initServer.sqf
@@ -5,6 +5,27 @@ createCenter east;
 setViewDistance 6000;
 setObjectViewDistance [6000,6000];
 
+/*
+true/false for attendance tracking active/inactive
+[
+	[
+		Player ID, ... , Player ID
+	]
+	,[
+		[Player Name, Time Played], ..., [Player Name, Time Played]
+	]
+]
+*/
+AttendanceTrackingData = profileNamespace getVariable ["SavedAttendanceTrackingData", nil];
+if (isNil "AttendanceTrackingData") then
+{
+	AttendanceTrackingData = [false,[[],[]]];
+};
+AttendanceTrackingActive = AttendanceTrackingData select 0;
+
+ActivateNewTracking = false;
+DeactivateCurrentTracking = false;
+
 setDate [2020, 6, 26, floor(random 24), 00];
 
 redforSkill = 0.7;
@@ -48,3 +69,5 @@ waitUntil {scriptDone _collectRedforHandle};
 [] execVM "MissionScripts\linkPlayersToZeus.sqf";
 
 [] execVM "MissionScripts\bluforVehicleExchangeServer.sqf";
+
+[] execVM "MissionScripts\attendanceTracker.sqf";

--- a/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.zargabad/mission.sqm
+++ b/Maps/7Cav_RHS_InvadeAndAnnex_DEVBUILD.zargabad/mission.sqm
@@ -8,7 +8,7 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=472;
+		nextID=473;
 	};
 	class MarkerIDProvider
 	{
@@ -16,10 +16,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={3351.7974,57.983337,7551.3472};
-		dir[]={-0.6099934,-0.331186,-0.71990728};
-		up[]={-0.21410426,0.94356018,-0.25268382};
-		aside[]={-0.76295912,1.4383113e-007,0.64647228};
+		pos[]={3362.2236,37.315575,79.705414};
+		dir[]={0.023524962,-0.52085537,0.85332233};
+		up[]={0.014353828,0.85364479,0.52065724};
+		aside[]={0.9996202,-1.670287e-009,-0.027558221};
 	};
 };
 binarizationWanted=0;
@@ -63,7 +63,8 @@ addons[]=
 	"rhsgref_c_weapons",
 	"rhsusf_c_weapons",
 	"A3_Characters_F_Mark",
-	"rhsusf_c_melb"
+	"rhsusf_c_melb",
+	"A3_Structures_F_Mil_Flags"
 };
 class AddonsMetaData
 {
@@ -322,7 +323,7 @@ class ScenarioData
 };
 class CustomAttributes
 {
-	class Category1
+	class Category0
 	{
 		name="Scenario";
 		class Attribute0
@@ -371,7 +372,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=142;
+		items=143;
 		class Item0
 		{
 			dataType="Marker";
@@ -9349,6 +9350,7 @@ class Mission
 					};
 					id=165;
 					type="B_soldier_repair_F";
+					atlOffset=-9.5367432e-007;
 					class CustomAttributes
 					{
 						class Attribute0
@@ -9485,6 +9487,7 @@ class Mission
 			{
 			};
 			id=164;
+			atlOffset=-9.5367432e-007;
 		};
 		class Item31
 		{
@@ -22065,6 +22068,46 @@ class Mission
 					};
 				};
 				nAttributes=2;
+			};
+		};
+		class Item142
+		{
+			dataType="Object";
+			class PositionInfo
+			{
+				position[]={3367.7297,17.233765,109.09055};
+			};
+			side="Empty";
+			flags=5;
+			class Attributes
+			{
+				name="attendance_flag";
+			};
+			id=472;
+			type="Flag_US_F";
+			atlOffset=-0.028999329;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="allowDamage";
+					expression="_this allowdamage _value;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				nAttributes=1;
 			};
 		};
 	};


### PR DESCRIPTION
Added attendance tracking activated via Flag Pole Scrollwheel Action by logged in admin.

This is to enable attendance tracking for longer events that take place on main rotation mission files.